### PR TITLE
GUACAMOLE-609: Add support for qemu extended key events

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@
 
 
 # Use Debian as base for the build
-ARG DEBIAN_VERSION=stable
+ARG DEBIAN_VERSION=stretch
 FROM debian:${DEBIAN_VERSION} AS builder
 
 # Base directory for installed build artifacts.

--- a/src/libguac/guacamole/user-fntypes.h
+++ b/src/libguac/guacamole/user-fntypes.h
@@ -113,7 +113,7 @@ typedef int guac_user_mouse_handler(guac_user* user, int x, int y,
  *     Zero if the key event was handled successfully, or non-zero if an error
  *     occurred.
  */
-typedef int guac_user_key_handler(guac_user* user, int keysym, int pressed);
+typedef int guac_user_key_handler(guac_user *user, int keysym, int pressed, int code);
 
 /**
  * Handler for Guacamole audio streams received from a user. Each such audio

--- a/src/libguac/user-handlers.c
+++ b/src/libguac/user-handlers.c
@@ -162,11 +162,15 @@ int __guac_handle_mouse(guac_user* user, int argc, char** argv) {
 }
 
 int __guac_handle_key(guac_user* user, int argc, char** argv) {
+    int keycode = 0;
+    if (argc == 3)
+      keycode = atoi(argv[2]);
     if (user->key_handler)
         return user->key_handler(
             user,
             atoi(argv[0]), /* keysym */
-            atoi(argv[1])  /* pressed */
+            atoi(argv[1]), /* pressed */
+            keycode        /* keycode */
         );
     return 0;
 }

--- a/src/protocols/kubernetes/input.c
+++ b/src/protocols/kubernetes/input.c
@@ -49,7 +49,7 @@ int guac_kubernetes_user_mouse_handler(guac_user* user,
 
 }
 
-int guac_kubernetes_user_key_handler(guac_user* user, int keysym, int pressed) {
+int guac_kubernetes_user_key_handler(guac_user *user, int keysym, int pressed, int code) {
 
     guac_client* client = user->client;
     guac_kubernetes_client* kubernetes_client =

--- a/src/protocols/rdp/input.c
+++ b/src/protocols/rdp/input.c
@@ -123,7 +123,7 @@ int guac_rdp_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     return 0;
 }
 
-int guac_rdp_user_key_handler(guac_user* user, int keysym, int pressed) {
+int guac_rdp_user_key_handler(guac_user *user, int keysym, int pressed, int code) {
 
     guac_client* client = user->client;
     guac_rdp_client* rdp_client = (guac_rdp_client*) client->data;

--- a/src/protocols/ssh/input.c
+++ b/src/protocols/ssh/input.c
@@ -50,7 +50,7 @@ int guac_ssh_user_mouse_handler(guac_user* user, int x, int y, int mask) {
     return 0;
 }
 
-int guac_ssh_user_key_handler(guac_user* user, int keysym, int pressed) {
+int guac_ssh_user_key_handler(guac_user *user, int keysym, int pressed, int code) {
 
     guac_client* client = user->client;
     guac_ssh_client* ssh_client = (guac_ssh_client*) client->data;

--- a/src/protocols/telnet/input.c
+++ b/src/protocols/telnet/input.c
@@ -56,7 +56,7 @@ int guac_telnet_user_mouse_handler(guac_user* user, int x, int y, int mask) {
 
 }
 
-int guac_telnet_user_key_handler(guac_user* user, int keysym, int pressed) {
+int guac_telnet_user_key_handler(guac_user* user, int keysym, int pressed, int code) {
 
     guac_client* client = user->client;
     guac_telnet_client* telnet_client = (guac_telnet_client*) client->data;

--- a/src/protocols/vnc/input.h
+++ b/src/protocols/vnc/input.h
@@ -25,6 +25,17 @@
 
 #include <guacamole/user.h>
 
+/* This is the qemu extended key event(for sending keycodes along with keysyms)*/
+typedef struct
+{
+  uint8_t type;     /* always 255 */
+  uint8_t subtype;  /* always 0 */
+  uint16_t down;    /* true if down (press), false if up */
+  uint32_t keysym;  /* key is specified as an X keysym */
+  uint32_t keycode; /* the raw xt keycode */
+} rfbQemuExtKeyEventMsg;
+#define sz_rfbQemuExtKeyEventMsg 12
+
 /**
  * Handler for Guacamole user mouse events.
  */

--- a/src/protocols/vnc/settings.h
+++ b/src/protocols/vnc/settings.h
@@ -256,6 +256,9 @@ typedef struct guac_vnc_settings {
      */
     bool recording_include_keys;
 
+    /* Whether the server supports extended qemu key events or not */
+    bool ext_qemu_key_events;
+
 } guac_vnc_settings;
 
 /**


### PR DESCRIPTION
This lets us send keycodes instead of just keysyms. The key message is
modified to take an optional 3rd argument indicating the raw XT Scancode
of the key that was pressed.

If the vnc server supports the qemu extended key extension, then we'll
send this scancode/keycode along with the keysym to the server. This
helps work around some keyboard oddities/inconsistencies between keysyms
and keycodes.